### PR TITLE
Support `properties_failures`

### DIFF
--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -133,6 +133,14 @@ defmodule AutoApi.State do
           end)
           |> Enum.join("")
         end
+
+        def parse_state_property(:properties_failures, failures) do
+          failures
+          |> Enum.map(fn {prop_name, failure} ->
+            AutoApi.State.parse_state_property_failures_to_bin(__MODULE__, prop_name, failure)
+          end)
+          |> Enum.join("")
+        end
       end
 
     spec = Poison.decode!(File.read!(opts[:spec_file]))
@@ -503,5 +511,13 @@ defmodule AutoApi.State do
     |> Map.put(property_name, property_vaule)
     |> Map.put(:property_timestamps, property_timestamps)
     |> Map.put(:properties, properties)
+  end
+
+  def parse_state_property_failures_to_bin(state_module, property_name, {reason, description}) do
+    prop_id = apply(state_module, :property_id, [property_name])
+    bin_reason = CommonData.convert_state_to_bin_failure_reason(reason)
+    size = byte_size(description) + 3
+
+    <<0xA5, size::16, prop_id, bin_reason, byte_size(description)::8, description::binary>>
   end
 end

--- a/lib/auto_api/states/common_data.ex
+++ b/lib/auto_api/states/common_data.ex
@@ -86,4 +86,11 @@ defmodule AutoApi.CommonData do
   defp get_timezone(_), do: ""
   defp get_zoneabbr(0), do: "UTC"
   defp get_zoneabbr(_), do: ""
+
+  def convert_bin_to_state_failure_reason(0x00), do: :rate_limit
+  def convert_bin_to_state_failure_reason(0x01), do: :execution_timeout
+  def convert_bin_to_state_failure_reason(0x02), do: :format_error
+  def convert_bin_to_state_failure_reason(0x03), do: :unauthorised
+  def convert_bin_to_state_failure_reason(0x04), do: :unknown
+  def convert_bin_to_state_failure_reason(0x05), do: :pending
 end

--- a/lib/auto_api/states/common_data.ex
+++ b/lib/auto_api/states/common_data.ex
@@ -93,4 +93,11 @@ defmodule AutoApi.CommonData do
   def convert_bin_to_state_failure_reason(0x03), do: :unauthorised
   def convert_bin_to_state_failure_reason(0x04), do: :unknown
   def convert_bin_to_state_failure_reason(0x05), do: :pending
+
+  def convert_state_to_bin_failure_reason(:rate_limit), do: 0x00
+  def convert_state_to_bin_failure_reason(:execution_timeout), do: 0x01
+  def convert_state_to_bin_failure_reason(:format_error), do: 0x02
+  def convert_state_to_bin_failure_reason(:unauthorised), do: 0x03
+  def convert_state_to_bin_failure_reason(:unknown), do: 0x04
+  def convert_state_to_bin_failure_reason(:pending), do: 0x05
 end

--- a/lib/auto_api/states/door_locks_state.ex
+++ b/lib/auto_api/states/door_locks_state.ex
@@ -29,7 +29,8 @@ defmodule AutoApi.DoorLocksState do
             positions: [],
             timestamp: nil,
             properties: [],
-            property_timestamps: %{}
+            property_timestamps: %{},
+            properties_failures: %{}
 
   use AutoApi.State, spec_file: "specs/door_locks.json"
 
@@ -53,7 +54,8 @@ defmodule AutoApi.DoorLocksState do
           inside_locks: list(inside_lock),
           positions: list(position),
           timestamp: DateTime.t() | nil,
-          properties: list(atom)
+          properties: list(atom),
+          properties_failures: map()
         }
 
   @doc """

--- a/test/auto_api/states/universal_properties_test.exs
+++ b/test/auto_api/states/universal_properties_test.exs
@@ -245,4 +245,26 @@ defmodule AutoApi.UniversalPropertiesTest do
       assert byte_size(DiagnosticsState.to_bin(state)) == 50
     end
   end
+
+  describe "properties_failures" do
+    test "converts bin failures to state" do
+      # Put some UTF-8 weirdness in for good measure
+      locks_desc = "Could not parse it (ノಠ益ಠ)ノ彡┻━┻"
+      inside_desc = "Stuff happens ¯\_(ツ)_/¯"
+
+      bin_state =
+        <<4, 0, 2, 2, 1, 4, 0, 2, 3, 0, 165, byte_size(locks_desc) + 3::16, 3, 2,
+          byte_size(locks_desc)::8, locks_desc::binary, 165, byte_size(inside_desc) + 3::16, 2, 4,
+          byte_size(inside_desc)::8, inside_desc::binary>>
+
+      state = DoorLocksState.from_bin(bin_state)
+
+      assert length(state.positions) == 2
+
+      assert state.properties_failures == %{
+               locks: {:format_error, locks_desc},
+               inside_locks: {:unknown, inside_desc}
+             }
+    end
+  end
 end


### PR DESCRIPTION
First tentative implementation of the failures.

Things I'm not sure about:

- `lib/auto_api/state.ex` is becoming a bit too long and complicated I think. Maybe it would make sense to extract the helper functions in another module and extract them
- I am not much happy with hardcoding the failure reason atom/byte conversion. Maybe we could include the `universal_properties` spec file and use it for generating them at compile time, as we do in `AutoApi.State.__using__/1`?