### PR TITLE
Add `AutoApi.State.put_failure`

### DIFF
--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -520,4 +520,13 @@ defmodule AutoApi.State do
 
     <<0xA5, size::16, prop_id, bin_reason, byte_size(description)::8, description::binary>>
   end
+
+  def put_failure(state, property, reason, description) do
+    properties = Enum.uniq([:properties_failures | state.properties])
+    failure_keys = [Access.key(:properties_failures), Access.key(property)]
+
+    state
+    |> Map.put(:properties, properties)
+    |> put_in(failure_keys, {reason, description})
+  end
 end

--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -521,6 +521,10 @@ defmodule AutoApi.State do
     <<0xA5, size::16, prop_id, bin_reason, byte_size(description)::8, description::binary>>
   end
 
+  def put_failure(state, property, reason, description) when byte_size(description) > 255 do
+    put_failure(state, property, reason, binary_part(description, 0, 255))
+  end
+
   def put_failure(state, property, reason, description) do
     properties = Enum.uniq([:properties_failures | state.properties])
     failure_keys = [Access.key(:properties_failures), Access.key(property)]

--- a/test/auto_api/states/universal_properties_test.exs
+++ b/test/auto_api/states/universal_properties_test.exs
@@ -283,5 +283,19 @@ defmodule AutoApi.UniversalPropertiesTest do
       assert String.contains?(bin, <<165, 0, 7, 2, 3, 4, 0xF0, 0x9F, 0x9A, 0xAB>>)
       assert String.contains?(bin, <<165, 0, 6, 4, 1, 3, 0xE2, 0x8F, 0xB0>>)
     end
+
+    test "sets a property failure" do
+      state =
+        DoorLocksState.base()
+        |> AutoApi.State.put_failure(:locks, :rate_limit, "🏎")
+        |> AutoApi.State.put_failure(:inside_locks, :unauthorised, "🚫")
+
+      assert state.properties == [:properties_failures]
+
+      assert state.properties_failures == %{
+               locks: {:rate_limit, "🏎"},
+               inside_locks: {:unauthorised, "🚫"}
+             }
+    end
   end
 end

--- a/test/auto_api/states/universal_properties_test.exs
+++ b/test/auto_api/states/universal_properties_test.exs
@@ -297,5 +297,24 @@ defmodule AutoApi.UniversalPropertiesTest do
                inside_locks: {:unauthorised, "🚫"}
              }
     end
+
+    test "ensures failure description is limited to 255 bytes" do
+      desc = """
+        孟郊《游子吟》
+        慈 母 手 中 线，
+        游 子 身 上 衣。
+        临 行 密 密 缝，
+        意 恐 迟 迟 归。
+        谁 言 寸 草 心，
+        报 得 三 春 晖。
+      """
+
+      state =
+        DoorLocksState.base()
+        |> AutoApi.State.put_failure(:locks, :unknown, desc <> desc)
+
+      assert %{locks: {:unknown, description}} = state.properties_failures
+      assert byte_size(description) <= 255
+    end
   end
 end


### PR DESCRIPTION
Proposed API name for the function that adds a property failure to a
state.

@slashmili created PR for asking for your opinion on the function name :)