### PR TITLE
update_property  state helper

### DIFF
--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -592,4 +592,14 @@ defmodule AutoApi.State do
     |> Map.put(:properties, properties)
     |> put_in(failure_keys, {reason, description})
   end
+
+  def put_value(state, key, value, timestamp \\ nil) do
+       Map.put(state, key, %AutoApi.PropertyComponent{data: value, timestamp: timestamp})
+  end
+
+  def append_value(state, key, value, timestamp \\ nil) do
+    initial = Map.get(state, key)
+    property_component = %AutoApi.PropertyComponent{data: value, timestamp: timestamp}
+    Map.update(state, key, initial, &(&1 ++ [property_component]))
+  end
 end

--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -594,12 +594,25 @@ defmodule AutoApi.State do
   end
 
   def put_value(state, key, value, timestamp \\ nil) do
-       Map.put(state, key, %AutoApi.PropertyComponent{data: value, timestamp: timestamp})
+    Map.put(state, key, %AutoApi.PropertyComponent{data: value, timestamp: timestamp})
   end
 
   def append_value(state, key, value, timestamp \\ nil) do
     initial = Map.get(state, key)
     property_component = %AutoApi.PropertyComponent{data: value, timestamp: timestamp}
     Map.update(state, key, initial, &(&1 ++ [property_component]))
+  end
+
+  @doc """
+  Update a property value in the given state.
+
+  If a property supports multiple value, appends the value to the property list
+  """
+  def update_value(state, key, value, timestamp \\ nil) do
+    if state.__struct__.is_multiple?(key) do
+      append_value(state, key, value, timestamp)
+    else
+      put_value(state, key, value, timestamp)
+    end
   end
 end

--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -599,11 +599,11 @@ defmodule AutoApi.State do
   If a property supports multiple value, appends the value to the property list
   """
   @spec update_property(map, atom(), any, DateTime.t() | nil) :: map
-  def update_property(state, key, value, timestamp \\ nil) do
-    if state.__struct__.is_multiple?(key) do
-      state.__struct__.append_property(state, key, value, timestamp)
+  def update_property(%state_module{} = state, key, value, timestamp \\ nil) do
+    if state_module.is_multiple?(key) do
+      state_module.append_property(state, key, value, timestamp)
     else
-      state.__struct__.put_property(state, key, value, timestamp)
+      state_module.put_property(state, key, value, timestamp)
     end
   end
 end

--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -593,26 +593,17 @@ defmodule AutoApi.State do
     |> put_in(failure_keys, {reason, description})
   end
 
-  def put_value(state, key, value, timestamp \\ nil) do
-    Map.put(state, key, %AutoApi.PropertyComponent{data: value, timestamp: timestamp})
-  end
-
-  def append_value(state, key, value, timestamp \\ nil) do
-    initial = Map.get(state, key)
-    property_component = %AutoApi.PropertyComponent{data: value, timestamp: timestamp}
-    Map.update(state, key, initial, &(&1 ++ [property_component]))
-  end
-
   @doc """
   Update a property value in the given state.
 
   If a property supports multiple value, appends the value to the property list
   """
-  def update_value(state, key, value, timestamp \\ nil) do
+  @spec update_property(map, atom(), any, DateTime.t() | nil) :: map
+  def update_property(state, key, value, timestamp \\ nil) do
     if state.__struct__.is_multiple?(key) do
-      append_value(state, key, value, timestamp)
+      state.__struct__.append_property(state, key, value, timestamp)
     else
-      put_value(state, key, value, timestamp)
+      state.__struct__.put_property(state, key, value, timestamp)
     end
   end
 end

--- a/test/auto_api/state_test.exs
+++ b/test/auto_api/state_test.exs
@@ -100,71 +100,11 @@ defmodule AutoApi.StateTest do
     end
   end
 
-  describe "put_value/4" do
-    test "put scalar value without timestamp" do
-      state = %DiagnosticsState{}
-      new_state = AutoApi.State.put_value(state, :mileage, 1000)
-
-      assert new_state.mileage.data == 1000
-    end
-
-    test "put scalar value with timestamp" do
-      now = DateTime.utc_now()
-      state = %DiagnosticsState{}
-      new_state = AutoApi.State.put_value(state, :mileage, 1000, now)
-
-      assert new_state.mileage.data == 1000
-      assert new_state.mileage.timestamp == now
-    end
-  end
-
-  describe "append_value/4" do
-    test "append values to state" do
-      state = %DiagnosticsState{}
-      assert state.tire_pressures == []
-
-      new_state =
-        AutoApi.State.append_value(state, :tire_pressures, %{
-          location: :front_right,
-          pressure: 1.938
-        })
-
-      assert tire_info = List.first(new_state.tire_pressures)
-      assert tire_info.data.location == :front_right
-      assert tire_info.data.pressure == 1.938
-
-      new_state =
-        AutoApi.State.append_value(new_state, :tire_pressures, %{
-          location: :front_right,
-          pressure: 1.938
-        })
-
-      assert length(new_state.tire_pressures) == 2
-    end
-
-    test "append values to state with timestamp" do
-      now = DateTime.utc_now()
-      state = %DiagnosticsState{}
-      assert state.tire_pressures == []
-
-      new_state =
-        AutoApi.State.append_value(
-          state,
-          :tire_pressures,
-          %{location: :front_right, pressure: 1.938},
-          now
-        )
-
-      assert tire_info = List.first(new_state.tire_pressures)
-      assert tire_info.timestamp == now
-    end
-  end
-
-  describe "update_value/4" do
+  describe "update_property/4" do
     test "update a property with single value" do
       now = DateTime.utc_now()
       state = %DiagnosticsState{}
-      new_state = AutoApi.State.update_value(state, :mileage, 1000, now)
+      new_state = AutoApi.State.update_property(state, :mileage, 1000, now)
 
       assert new_state.mileage.data == 1000
       assert new_state.mileage.timestamp == now
@@ -176,7 +116,7 @@ defmodule AutoApi.StateTest do
       assert state.tire_pressures == []
 
       new_state =
-        AutoApi.State.append_value(
+        AutoApi.State.update_property(
           state,
           :tire_pressures,
           %{location: :front_right, pressure: 1.938},

--- a/test/auto_api/state_test.exs
+++ b/test/auto_api/state_test.exs
@@ -107,6 +107,7 @@ defmodule AutoApi.StateTest do
 
       assert new_state.mileage.data == 1000
     end
+
     test "put scalar value with timestamp" do
       now = DateTime.utc_now()
       state = %DiagnosticsState{}
@@ -121,11 +122,23 @@ defmodule AutoApi.StateTest do
     test "append values to state" do
       state = %DiagnosticsState{}
       assert state.tire_pressures == []
-      new_state = AutoApi.State.append_value(state, :tire_pressures, %{location: :front_right, pressure: 1.938})
+
+      new_state =
+        AutoApi.State.append_value(state, :tire_pressures, %{
+          location: :front_right,
+          pressure: 1.938
+        })
+
       assert tire_info = List.first(new_state.tire_pressures)
       assert tire_info.data.location == :front_right
       assert tire_info.data.pressure == 1.938
-      new_state = AutoApi.State.append_value(new_state, :tire_pressures, %{location: :front_right, pressure: 1.938})
+
+      new_state =
+        AutoApi.State.append_value(new_state, :tire_pressures, %{
+          location: :front_right,
+          pressure: 1.938
+        })
+
       assert length(new_state.tire_pressures) == 2
     end
 
@@ -133,7 +146,43 @@ defmodule AutoApi.StateTest do
       now = DateTime.utc_now()
       state = %DiagnosticsState{}
       assert state.tire_pressures == []
-      new_state = AutoApi.State.append_value(state, :tire_pressures, %{location: :front_right, pressure: 1.938}, now)
+
+      new_state =
+        AutoApi.State.append_value(
+          state,
+          :tire_pressures,
+          %{location: :front_right, pressure: 1.938},
+          now
+        )
+
+      assert tire_info = List.first(new_state.tire_pressures)
+      assert tire_info.timestamp == now
+    end
+  end
+
+  describe "update_value/4" do
+    test "update a property with single value" do
+      now = DateTime.utc_now()
+      state = %DiagnosticsState{}
+      new_state = AutoApi.State.update_value(state, :mileage, 1000, now)
+
+      assert new_state.mileage.data == 1000
+      assert new_state.mileage.timestamp == now
+    end
+
+    test "update a property with multiple valus " do
+      now = DateTime.utc_now()
+      state = %DiagnosticsState{}
+      assert state.tire_pressures == []
+
+      new_state =
+        AutoApi.State.append_value(
+          state,
+          :tire_pressures,
+          %{location: :front_right, pressure: 1.938},
+          now
+        )
+
       assert tire_info = List.first(new_state.tire_pressures)
       assert tire_info.timestamp == now
     end

--- a/test/auto_api/state_test.exs
+++ b/test/auto_api/state_test.exs
@@ -99,4 +99,43 @@ defmodule AutoApi.StateTest do
       assert state.tire_pressures == [tire_pressures]
     end
   end
+
+  describe "put_value/4" do
+    test "put scalar value without timestamp" do
+      state = %DiagnosticsState{}
+      new_state = AutoApi.State.put_value(state, :mileage, 1000)
+
+      assert new_state.mileage.data == 1000
+    end
+    test "put scalar value with timestamp" do
+      now = DateTime.utc_now()
+      state = %DiagnosticsState{}
+      new_state = AutoApi.State.put_value(state, :mileage, 1000, now)
+
+      assert new_state.mileage.data == 1000
+      assert new_state.mileage.timestamp == now
+    end
+  end
+
+  describe "append_value/4" do
+    test "append values to state" do
+      state = %DiagnosticsState{}
+      assert state.tire_pressures == []
+      new_state = AutoApi.State.append_value(state, :tire_pressures, %{location: :front_right, pressure: 1.938})
+      assert tire_info = List.first(new_state.tire_pressures)
+      assert tire_info.data.location == :front_right
+      assert tire_info.data.pressure == 1.938
+      new_state = AutoApi.State.append_value(new_state, :tire_pressures, %{location: :front_right, pressure: 1.938})
+      assert length(new_state.tire_pressures) == 2
+    end
+
+    test "append values to state with timestamp" do
+      now = DateTime.utc_now()
+      state = %DiagnosticsState{}
+      assert state.tire_pressures == []
+      new_state = AutoApi.State.append_value(state, :tire_pressures, %{location: :front_right, pressure: 1.938}, now)
+      assert tire_info = List.first(new_state.tire_pressures)
+      assert tire_info.timestamp == now
+    end
+  end
 end


### PR DESCRIPTION
`update_property` helper makes it easier to update a property without explicitly knowing the state module! 