### PR TITLE
update failure_message state and command

### DIFF
--- a/lib/auto_api/property_component.ex
+++ b/lib/auto_api/property_component.ex
@@ -66,6 +66,8 @@ defmodule AutoApi.PropertyComponent do
       |> Enum.find(%{}, &(&1["name"] == Atom.to_string(data)))
       |> Map.get("id")
 
+    unless enum_id, do: Logger.warn("Enum key `#{data}` doesn't exist in #{inspect spec}")
+
     <<enum_id>>
   end
 

--- a/lib/auto_api/states/failure_message_state.ex
+++ b/lib/auto_api/states/failure_message_state.ex
@@ -21,6 +21,8 @@ defmodule AutoApi.FailureMessageState do
   Keeps Charging state
   """
 
+  alias AutoApi.PropertyComponent
+
   @type failure_reason ::
           :unsupported_capability
           | :unauthorised
@@ -37,18 +39,16 @@ defmodule AutoApi.FailureMessageState do
             failed_message_type: nil,
             failure_reason: nil,
             failure_description: nil,
-            timestamp: nil,
-            properties: []
+            timestamp: nil
 
   use AutoApi.State, spec_file: "specs/failure_message.json"
 
   @type t :: %__MODULE__{
-          failed_message_identifier: integer | nil,
-          failed_message_type: integer | nil,
-          failure_reason: failure_reason :: nil,
-          failure_description: String.t() | nil,
-          timestamp: DateTime.t() | nil,
-          properties: list(atom)
+          failed_message_identifier: %PropertyComponent{data: integer} | nil,
+          failed_message_type: %PropertyComponent{data: integer} | nil,
+          failure_reason: %PropertyComponent{data: failure_reason} :: nil,
+          failure_description: %PropertyComponent{data: String.t()} | nil,
+          timestamp: DateTime.t() | nil
         }
 
   @doc """
@@ -71,14 +71,18 @@ defmodule AutoApi.FailureMessageState do
     |> parse_state_properties()
   end
 
-  defp unify_unauthorized_from_bin(%{failure_reason: :unauthorised} = state) do
-    %{state | failure_reason: :unauthorized}
+  defp unify_unauthorized_from_bin(
+         %{failure_reason: %{data: :unauthorised} = failure_reason} = state
+       ) do
+    %{state | failure_reason: %{failure_reason | data: :unauthorized}}
   end
 
   defp unify_unauthorized_from_bin(value), do: value
 
-  defp unify_unauthorized_to_bin(%{failure_reason: :unauthorized} = state) do
-    %{state | failure_reason: :unauthorised}
+  defp unify_unauthorized_to_bin(
+         %{failure_reason: %{data: :unauthorized} = failure_reason} = state
+       ) do
+    %{state | failure_reason: %{failure_reason | data: :unauthorised}}
   end
 
   defp unify_unauthorized_to_bin(value), do: value

--- a/test/auto_api/commands/failure_message_command_test.exs
+++ b/test/auto_api/commands/failure_message_command_test.exs
@@ -18,5 +18,29 @@
 # licensing@high-mobility.com
 defmodule AutoApi.FailureMessageCommandTest do
   use ExUnit.Case
-  doctest AutoApi.FailureMessageCommand
+  alias AutoApi.{FailureMessageCommand, FailureMessageState}
+
+  setup do
+    state =
+      %FailureMessageState{}
+      |> FailureMessageState.put_property(:failure_description, "desc")
+      |> FailureMessageState.put_property(:failure_reason, :vehicle_asleep)
+
+    {:ok, %{state: state}}
+  end
+
+  describe "execute/2" do
+    test "failure", %{state: state} do
+      cmd = <<0x01>> <> FailureMessageState.to_bin(state)
+
+      assert FailureMessageCommand.execute(%FailureMessageState{}, cmd) ==
+               {:state_changed, state}
+    end
+  end
+
+  describe "state/1" do
+    test "get state", %{state: state} do
+      assert FailureMessageCommand.state(state) == <<0x01>> <> FailureMessageState.to_bin(state)
+    end
+  end
 end

--- a/test/auto_api/states/failure_message_state_test.exs
+++ b/test/auto_api/states/failure_message_state_test.exs
@@ -18,5 +18,24 @@
 # licensing@high-mobility.com
 defmodule AutoApi.FailureMessageStateTest do
   use ExUnit.Case
-  doctest AutoApi.FailureMessageState
+  alias AutoApi.FailureMessageState
+
+  test "to_bin & from_bin" do
+    state =
+      %FailureMessageState{}
+      |> FailureMessageState.put_property(:failed_message_identifier, 0x35)
+      |> FailureMessageState.put_property(:failed_message_type, 0x00)
+      |> FailureMessageState.put_property(:failure_reason, :unauthorized)
+      |> FailureMessageState.put_property(
+        :failure_description,
+        "Access to this capability was not granted"
+      )
+
+    new_state =
+      state
+      |> FailureMessageState.to_bin()
+      |> FailureMessageState.from_bin()
+
+    assert new_state == state
+  end
 end


### PR DESCRIPTION
@jhaesus Updating to level 10 includes : 
1. Check if there is any update in `api_update` for the capability in our bitbucket repo. if there is you need to update the `spec/<CAP_NAME>.json`
2. Check lib/auto_api/states/failure_message_state.ex (failure_message is the capability)
   1. if there is new property(after updating spec)
   2. update `@spec`, the properties are wrapped with `PropertyComponent`
   3. update test for the capability
3. check lib/auto_api/commands/failure_message_command.ex
  1. update test for the capability