### PR TITLE
Add several methods to AutoApi.Capability

### DIFF
--- a/lib/auto_api/capability.ex
+++ b/lib/auto_api/capability.ex
@@ -302,7 +302,7 @@ defmodule AutoApi.Capability do
   iex> AutoApi.Capability.get_by_name("Nobody")
   nil
   """
-  @spec get_by_name(binary) :: module
+  @spec get_by_name(binary | atom) :: module
   defdelegate get_by_name(name), to: AutoApi.CapabilityDelegate
 
   @doc """

--- a/lib/auto_api/capability.ex
+++ b/lib/auto_api/capability.ex
@@ -231,60 +231,6 @@ defmodule AutoApi.Capability do
     end
   end
 
-  @capabilities %{
-    <<0x00, 0x2>> => AutoApi.FailureMessageCapability,
-    <<0x00, 0x03>> => AutoApi.FirmwareVersionCapability,
-    <<0x00, 0x10>> => AutoApi.CapabilitiesCapability,
-    <<0x00, 0x33>> => AutoApi.DiagnosticsCapability,
-    <<0x00, 0x20>> => AutoApi.DoorLocksCapability,
-    <<0x00, 0x42>> => AutoApi.WindscreenCapability,
-    <<0x00, 0x45>> => AutoApi.WindowsCapability,
-    <<0x00, 0x59>> => AutoApi.WiFiCapability,
-    <<0x00, 0x55>> => AutoApi.WeatherConditionsCapability,
-    <<0x00, 0x22>> => AutoApi.WakeUpCapability,
-    <<0x00, 0x43>> => AutoApi.VideoHandoverCapability,
-    <<0x00, 0x50>> => AutoApi.VehicleTimeCapability,
-    <<0x00, 0x11>> => AutoApi.VehicleStatusCapability,
-    <<0x00, 0x30>> => AutoApi.VehicleLocationCapability,
-    <<0x00, 0x21>> => AutoApi.TrunkCapability,
-    <<0x00, 0x46>> => AutoApi.TheftAlarmCapability,
-    <<0x00, 0x44>> => AutoApi.TextInputCapability,
-    <<0x00, 0x25>> => AutoApi.RooftopControlCapability,
-    <<0x00, 0x27>> => AutoApi.RemoteControlCapability,
-    <<0x00, 0x28>> => AutoApi.ValetModeCapability,
-    <<0x00, 0x57>> => AutoApi.RaceCapability,
-    <<0x00, 0x47>> => AutoApi.ParkingTicketCapability,
-    <<0x00, 0x58>> => AutoApi.ParkingBrakeCapability,
-    <<0x00, 0x65>> => AutoApi.PowerTakeoffCapability,
-    <<0x00, 0x56>> => AutoApi.SeatsCapability,
-    <<0x00, 0x34>> => AutoApi.MaintenanceCapability,
-    <<0x00, 0x49>> => AutoApi.BrowserCapability,
-    <<0x00, 0x23>> => AutoApi.ChargingCapability,
-    <<0x00, 0x53>> => AutoApi.ChassisSettingsCapability,
-    <<0x00, 0x24>> => AutoApi.ClimateCapability,
-    <<0x00, 0x41>> => AutoApi.DriverFatigueCapability,
-    <<0x00, 0x35>> => AutoApi.EngineCapability,
-    <<0x00, 0x40>> => AutoApi.FuelingCapability,
-    <<0x00, 0x51>> => AutoApi.GraphicsCapability,
-    <<0x00, 0x29>> => AutoApi.HeartRateCapability,
-    <<0x00, 0x60>> => AutoApi.HomeChargerCapability,
-    <<0x00, 0x48>> => AutoApi.KeyfobPositionCapability,
-    <<0x00, 0x36>> => AutoApi.LightsCapability,
-    <<0x00, 0x54>> => AutoApi.LightConditionsCapability,
-    <<0x00, 0x37>> => AutoApi.MessagingCapability,
-    <<0x00, 0x31>> => AutoApi.NaviDestinationCapability,
-    <<0x00, 0x38>> => AutoApi.NotificationsCapability,
-    <<0x00, 0x52>> => AutoApi.OffroadCapability,
-    <<0x00, 0x26>> => AutoApi.HonkHornFlashLightsCapability,
-    <<0x00, 0x67>> => AutoApi.HoodCapability,
-    <<0x00, 0x61>> => AutoApi.DashboardLightsCapability,
-    <<0x00, 0x63>> => AutoApi.StartStopCapability,
-    <<0x00, 0x64>> => AutoApi.TachographCapability,
-    <<0x00, 0x62>> => AutoApi.CruiseControlCapability,
-    <<0x00, 0x66>> => AutoApi.MobileCapability,
-    <<0x00, 0x68>> => AutoApi.UsageCapability
-  }
-
   @doc """
     Returns full capabilities with all of them marked as disabled
 
@@ -295,9 +241,9 @@ defmodule AutoApi.Capability do
       <<0, 0x20, 0>>
   """
   def blank_capabilities do
-    caps_len = length(Map.keys(@capabilities))
+    caps_len = length(all())
 
-    for {_, cap_module} <- @capabilities do
+    for cap_module <- all() do
       iden = apply(cap_module, :identifier, [])
 
       cap_module
@@ -308,5 +254,67 @@ defmodule AutoApi.Capability do
     |> Enum.reduce(<<caps_len>>, fn i, x -> x <> i end)
   end
 
-  def list_capabilities, do: @capabilities
+  @doc """
+  Returns a list of all capability modules.
+
+  ## Examples
+
+  iex> capabilities = AutoApi.Capability.all()
+  iex> length(capabilities)
+  51
+  iex> List.first(capabilities)
+  AutoApi.BrowserCapability
+  """
+  @spec all() :: list(module)
+  defdelegate all(), to: AutoApi.CapabilityDelegate
+
+  @doc """
+  Returns a capability module by its binary id.
+
+  Returns `nil` if there is no capability with the given id.
+
+  ## Examples
+
+  iex> AutoApi.Capability.get_by_id(<<0x00, 0x35>>)
+  AutoApi.EngineCapability
+
+  iex> AutoApi.Capability.get_by_id(<<0xDE, 0xAD>>)
+  nil
+  """
+  @spec get_by_id(binary) :: module
+  defdelegate get_by_id(id), to: AutoApi.CapabilityDelegate
+
+  @doc """
+  Returns a capability module by its name.
+
+  The name can be specified either as an atom or a string.
+
+  Returns `nil` if there is no capability with the given name.
+
+  ## Examples
+
+  iex> AutoApi.Capability.get_by_name("door_locks")
+  AutoApi.DoorLocksCapability
+
+  iex> AutoApi.Capability.get_by_name(:wake_up)
+  AutoApi.WakeUpCapability
+
+  iex> AutoApi.Capability.get_by_name("Nobody")
+  nil
+  """
+  @spec get_by_name(binary) :: module
+  defdelegate get_by_name(name), to: AutoApi.CapabilityDelegate
+
+  @doc """
+  Returns a map with the capability identifiers as keys and the modules as values.
+
+  ## Examples
+
+  iex> capabilities = AutoApi.Capability.all()
+  iex> list = Enum.into(capabilities, %{}, &{&1.identifier, &1})
+  iex> AutoApi.Capability.list_capabilities == list
+  true
+  """
+  @deprecated "Use all/0 and AutoApi.Capability.identifier/0 instead"
+  defdelegate list_capabilities(), to: AutoApi.CapabilityDelegate
 end

--- a/lib/auto_api/capability_delegate.ex
+++ b/lib/auto_api/capability_delegate.ex
@@ -1,0 +1,4 @@
+defmodule AutoApi.CapabilityDelegate do
+  @moduledoc false
+  @before_compile AutoApi.CapabilityHelper
+end

--- a/lib/auto_api/capability_delegate.ex
+++ b/lib/auto_api/capability_delegate.ex
@@ -1,3 +1,21 @@
+# AutoAPI
+# Copyright (C) 2018 High-Mobility GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# Please inquire about commercial licensing options at
+# licensing@high-mobility.com
 defmodule AutoApi.CapabilityDelegate do
   @moduledoc false
   @before_compile AutoApi.CapabilityHelper

--- a/lib/auto_api/capability_helper.ex
+++ b/lib/auto_api/capability_helper.ex
@@ -1,0 +1,114 @@
+# AutoAPI
+# Copyright (C) 2018 High-Mobility GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# Please inquire about commercial licensing options at
+# licensing@high-mobility.com
+defmodule AutoApi.CapabilityHelper do
+  @moduledoc false
+
+  # We could parse the files in `/specs` instead
+  @capabilities [
+    AutoApi.BrowserCapability,
+    AutoApi.CapabilitiesCapability,
+    AutoApi.ChargingCapability,
+    AutoApi.ChassisSettingsCapability,
+    AutoApi.ClimateCapability,
+    AutoApi.CruiseControlCapability,
+    AutoApi.DashboardLightsCapability,
+    AutoApi.DiagnosticsCapability,
+    AutoApi.DoorLocksCapability,
+    AutoApi.DriverFatigueCapability,
+    AutoApi.EngineCapability,
+    AutoApi.FailureMessageCapability,
+    AutoApi.FirmwareVersionCapability,
+    AutoApi.FuelingCapability,
+    AutoApi.GraphicsCapability,
+    AutoApi.HeartRateCapability,
+    AutoApi.HomeChargerCapability,
+    AutoApi.HonkHornFlashLightsCapability,
+    AutoApi.HoodCapability,
+    AutoApi.KeyfobPositionCapability,
+    AutoApi.LightConditionsCapability,
+    AutoApi.LightsCapability,
+    AutoApi.MaintenanceCapability,
+    AutoApi.MessagingCapability,
+    AutoApi.MobileCapability,
+    AutoApi.NaviDestinationCapability,
+    AutoApi.NotificationsCapability,
+    AutoApi.OffroadCapability,
+    AutoApi.ParkingBrakeCapability,
+    AutoApi.ParkingTicketCapability,
+    AutoApi.PowerTakeoffCapability,
+    AutoApi.RaceCapability,
+    AutoApi.RemoteControlCapability,
+    AutoApi.RooftopControlCapability,
+    AutoApi.SeatsCapability,
+    AutoApi.StartStopCapability,
+    AutoApi.TachographCapability,
+    AutoApi.TextInputCapability,
+    AutoApi.TheftAlarmCapability,
+    AutoApi.TrunkCapability,
+    AutoApi.UsageCapability,
+    AutoApi.ValetModeCapability,
+    AutoApi.VehicleLocationCapability,
+    AutoApi.VehicleStatusCapability,
+    AutoApi.VehicleTimeCapability,
+    AutoApi.VideoHandoverCapability,
+    AutoApi.WakeUpCapability,
+    AutoApi.WeatherConditionsCapability,
+    AutoApi.WiFiCapability,
+    AutoApi.WindowsCapability,
+    AutoApi.WindscreenCapability
+  ]
+
+  defmacro __before_compile__(_env) do
+    capabilities = @capabilities
+
+    ids_modules =
+      @capabilities
+      |> Enum.into(%{}, fn mod -> {apply(mod, :identifier, []), mod} end)
+      |> Macro.escape()
+
+    names_modules =
+      @capabilities
+      |> Enum.into(%{}, fn mod -> {apply(mod, :name, []), mod} end)
+      |> Macro.escape()
+
+    quote do
+      @capabilities unquote(capabilities)
+      @capability_ids_to_modules unquote(ids_modules)
+      @capability_names_to_modules unquote(names_modules)
+
+      def all(), do: @capabilities
+
+      def get_by_id(id), do: @capability_ids_to_modules[id]
+
+      def get_by_name(name) when is_binary(name) do
+        try do
+          get_by_name(String.to_existing_atom(name))
+        rescue
+          ArgumentError -> nil
+        end
+      end
+
+      def get_by_name(name), do: @capability_names_to_modules[name]
+
+      def list_capabilities() do
+        Enum.into(all(), %{}, &{&1.identifier, &1})
+      end
+    end
+  end
+end

--- a/test/auto_api/capability_test.exs
+++ b/test/auto_api/capability_test.exs
@@ -19,4 +19,32 @@
 defmodule AutoApi.CapabilityTest do
   use ExUnit.Case
   doctest AutoApi.Capability
+
+  alias AutoApi.Capability
+
+  test "all/0 does not contain duplicates" do
+    assert Enum.uniq(Capability.all()) == Capability.all()
+  end
+
+  test "get_by_name/1 works with all capabilities" do
+    capabilities = Capability.all()
+
+    assert Enum.all?(capabilities, fn cap ->
+             Capability.get_by_name(cap.name) == cap
+           end)
+  end
+
+  test "get_by_id/1 works with all capabilities" do
+    capabilities = Capability.all()
+
+    assert Enum.all?(capabilities, fn cap ->
+             Capability.get_by_id(cap.identifier) == cap
+           end)
+  end
+
+  test "list_capabilities/0 returns legacy format" do
+    cap_ids = Enum.into(Capability.all(), %{}, &{&1.identifier, &1})
+
+    assert cap_ids == Capability.list_capabilities()
+  end
 end


### PR DESCRIPTION
* all/0 returns a list of all capabilities, sorted alphabetically

* get_by_id/1 to search for a capability by id

* get_by_name/1 to search for a capability by its name

AutoApi.Capability.list_capabilities is now deprecated.