### PR TITLE
add example to convert command to bin

### DIFF
--- a/lib/auto_api/commands/diagnostics_command.ex
+++ b/lib/auto_api/commands/diagnostics_command.ex
@@ -59,4 +59,9 @@ defmodule AutoApi.DiagnosticsCommand do
     cmd_id = DiagnosticsCapability.command_id(:get_diagnostics_state)
     <<cmd_id>>
   end
+
+  def to_bin(:diagnostics_state = cmd, [state_value]) do
+    cmd_id = DiagnosticsCapability.command_id(cmd)
+    <<cmd_id>> <> DiagnosticsState.to_bin(state_value)
+  end
 end

--- a/test/auto_api/command_test.exs
+++ b/test/auto_api/command_test.exs
@@ -18,5 +18,18 @@
 # licensing@high-mobility.com
 defmodule AutoApi.CommandTest do
   use ExUnit.Case
+  alias AutoApi.{Command, DiagnosticsState, DiagnosticsCapability}
   doctest AutoApi.Command
+
+  describe "to_bin/3" do
+    test "convert diagnostics_state command" do
+      state =
+        %DiagnosticsState{}
+        |> DiagnosticsState.put_property(:mileage, 100)
+        |> DiagnosticsState.put_property(:fuel_level, 10)
+
+      expected_bin = DiagnosticsCapability.identifier() <> <<1>> <> DiagnosticsState.to_bin(state)
+      assert Command.to_bin(:diagnostics, :diagnostics_state, [state]) == expected_bin
+    end
+  end
 end

--- a/test/auto_api/commands/diagnostics_command_test.exs
+++ b/test/auto_api/commands/diagnostics_command_test.exs
@@ -43,4 +43,13 @@ defmodule AutoApi.DiagnosticsCommandTest do
       assert DiagnosticsCommand.state(state) == <<0x01>> <> DiagnosticsState.to_bin(state)
     end
   end
+
+  describe "to_bin/2" do
+    test "get state command" do
+      state = %DiagnosticsState{mileage: %PropertyComponent{data: 100}}
+
+      assert DiagnosticsCommand.to_bin(:diagnostics_state, [state]) ==
+               <<0x01>> <> DiagnosticsState.to_bin(state)
+    end
+  end
 end


### PR DESCRIPTION
This is an example how the user of this library could convert a command to it's binary value

```elixir
AutoApi.Command.to_bin(:diagnostics, :diagnostics_state, [%DiagnosticsState{}])
```