### PR TITLE
Handle property_component when type is enum and data is nil

### DIFF
--- a/lib/auto_api/property_component.ex
+++ b/lib/auto_api/property_component.ex
@@ -176,6 +176,10 @@ defmodule AutoApi.PropertyComponent do
     %__MODULE__{data: data, timestamp: timestamp, failure: failure}
   end
 
+  defp enum_to_value(nil, %{"size" => size} = spec) do
+    nil
+  end
+
   defp enum_to_value(binary_data, %{"size" => size} = spec) do
     size_bit = size * 8
     <<enum_id::integer-size(size_bit)>> = binary_data

--- a/lib/auto_api/state.ex
+++ b/lib/auto_api/state.ex
@@ -278,7 +278,7 @@ defmodule AutoApi.State do
                     unquote(Macro.escape(prop))
                   )
 
-                case property_component.data do
+                case property_component.data || property_component.failure do
                   nil ->
                     throw({:error, {:can_not_parse_enum, property_component_binary}})
 

--- a/test/auto_api/property_component_test.exs
+++ b/test/auto_api/property_component_test.exs
@@ -119,6 +119,30 @@ defmodule AutoApi.PropertyComponentTest do
       assert prop_comp.failure == nil
     end
 
+    test "converts enum to bin when it's nil" do
+      spec = %{
+        "type" => "enum",
+        "name" => "brake_fluid_level",
+        "size" => 1,
+        "values" => [
+          %{"id" => 0x00, "name" => "low"},
+          %{"id" => 1, "name" => "filled"}
+        ]
+      }
+
+      prop_bin =
+        PropertyComponent.to_bin(
+          %PropertyComponent{failure: %{reason: :unknown, description: ""}},
+          spec
+        )
+
+      prop_comp = PropertyComponent.to_struct(prop_bin, spec)
+
+      refute prop_comp.data
+      refute prop_comp.timestamp
+      assert prop_comp.failure == %{reason: :unknown, description: ""}
+    end
+
     test "converts capability_state to bin" do
       datetime = DateTime.utc_now()
 

--- a/test/auto_api/state_test.exs
+++ b/test/auto_api/state_test.exs
@@ -24,7 +24,8 @@ defmodule AutoApi.StateTest do
     State,
     DiagnosticsState,
     VehicleLocationState,
-    VehicleStatusState
+    VehicleStatusState,
+    RooftopControlState
   }
 
   describe "symmetric from_bin/1 & to_bin/1" do
@@ -128,6 +129,20 @@ defmodule AutoApi.StateTest do
         |> VehicleLocationState.from_bin()
 
       assert new_state.coordinates == coordinates
+    end
+
+    test "converts enum with nil value to bin and back to struct" do
+      state = %RooftopControlState{
+        sunroof_state: %PropertyComponent{failure: %{reason: :unknown, description: ""}},
+        sunroof_tilt_state: %PropertyComponent{failure: %{reason: :unknown, description: ""}}
+      }
+
+      new_state =
+        state
+        |> RooftopControlState.to_bin()
+        |> RooftopControlState.from_bin()
+
+      assert state == new_state
     end
   end
 


### PR DESCRIPTION
When the data is empty and failure presents, we had some issue in parsing binary back to struct